### PR TITLE
Transfers: bank to any game, game to game

### DIFF
--- a/src/PKForge.App/MauiProgram.cs
+++ b/src/PKForge.App/MauiProgram.cs
@@ -42,6 +42,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<GamepadRouter>();
         builder.Services.AddSingleton<SecondScreenState>();
         builder.Services.AddSingleton<SpritePackDownloader>();
+        builder.Services.AddSingleton<TransferService>();
 #if ANDROID
         builder.Services.AddSingleton<ISaveFileAccess, AndroidSafFileAccess>();
         builder.Services.AddSingleton<IDocumentPicker, AndroidDocumentPicker>();
@@ -55,7 +56,7 @@ public static class MauiProgram
         builder.Services.AddTransient<BoxBrowserPage>();
         builder.Services.AddTransient<BackupHistoryViewModel>();
         builder.Services.AddTransient<BackupHistoryPage>();
-        builder.Services.AddTransient<SavePickerViewModel>();
+        builder.Services.AddSingleton<SavePickerViewModel>();
         builder.Services.AddTransient<HomePage>();
         builder.Services.AddTransient<SecondScreenBoxPage>();
         builder.Services.AddTransient<BankPage>();

--- a/src/PKForge.App/Services/TransferService.cs
+++ b/src/PKForge.App/Services/TransferService.cs
@@ -1,0 +1,38 @@
+using PKForge.Domain;
+
+namespace PKForge.App.Services;
+
+/// <summary>Outcome of a bank-to-game or game-to-game transfer.</summary>
+public sealed record TransferOutcome(bool Success, string Message, int Box = -1, int Slot = -1, string? BackupId = null);
+
+/// <summary>
+/// Moves one Pokémon into a game save without touching the currently connected session.
+/// The target save is opened as a throwaway engine session, the entity is converted to
+/// its format by the engine (Gen 1 to Gen 9 either way), and the write goes through the
+/// same validate, backup, atomic-write pipeline as every other mutation.
+/// </summary>
+public sealed class TransferService(ISaveEngine engine, ISafeSaveWriter writer, ISaveFileAccess access)
+{
+    /// <summary>Places the entity into the first empty slot of the target save, across every box.</summary>
+    public async Task<TransferOutcome> SendToGameAsync(
+        ReadOnlyMemory<byte> entityBytes, string nickname, DetectedSave target, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        var bytes = await access.ReadAsync(target.DocumentId, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var session = engine.OpenSession(bytes.ToArray(), target.GameLabel);
+        var snapshot = session.Snapshot;
+
+        var landing = snapshot.Slots.FirstOrDefault(s => s.Species is null);
+        if (landing is null)
+            return new TransferOutcome(false, $"{target.GameLabel} has no empty slot in any box.");
+
+        if (!session.ImportSlot(landing.Box, landing.Slot, entityBytes.ToArray()))
+            return new TransferOutcome(false, $"{nickname} cannot enter {target.GameLabel}'s format.");
+
+        var receipt = await writer.WriteAsync(target.DocumentId, snapshot, session.Serialize(), cancellationToken).ConfigureAwait(false);
+        return new TransferOutcome(true, $"{nickname} joined {target.GameLabel} (box {landing.Box + 1}).", landing.Box, landing.Slot, receipt.BackupId);
+    }
+}

--- a/src/PKForge.App/ViewModels/BoxBrowserViewModel.cs
+++ b/src/PKForge.App/ViewModels/BoxBrowserViewModel.cs
@@ -361,11 +361,15 @@ public partial class BoxBrowserViewModel : ObservableObject, IBoxPager
     }, TaskScheduler.FromCurrentSynchronizationContext());
 
     /// <summary>Releases every marked mon. One backup, one write.</summary>
-    public Task<bool> BulkReleaseAsync() => RunMutationAsync(session =>
+    public Task<bool> BulkReleaseAsync() => BulkReleaseAsync(null);
+
+    /// <summary>Releases only the given slots (or every marked mon when null). One backup, one write.</summary>
+    public Task<bool> BulkReleaseAsync(IReadOnlyList<(int Box, int Slot)>? only) => RunMutationAsync(session =>
     {
-        foreach (var (box, slot) in _marked)
+        var targets = only ?? _marked.Select(m => (m.Box, m.Slot)).ToList();
+        foreach (var (box, slot) in targets)
             session.ReleaseSlot(box, slot);
-        return new GenerationOutcome(true, $"Released {_marked.Count} Pokémon. Bye-bye!");
+        return new GenerationOutcome(true, $"Released {targets.Count} Pokémon. Bye-bye!");
     }, Math.Max(0, SelectedSlot)).ContinueWith(t =>
     {
         RefreshAllSlots();

--- a/src/PKForge.App/Views/BankPage.cs
+++ b/src/PKForge.App/Views/BankPage.cs
@@ -209,11 +209,10 @@ public sealed class BankPage : ContentPage, IPadHandler
             return;
         }
 
-        var canSend = _boxViewModel.Save is not null;
         var choice = await PadMenu.ShowAsync(_hostGrid, entry.Info.Nickname.ToUpperInvariant(),
             $"From {entry.Info.SourceName} · Gen {entry.Info.Generation} · deposited {entry.AddedUtc:yyyy-MM-dd}",
             new PadOption("Edit", IconPath: "editor"),
-            new PadOption(canSend ? "Send to game" : "Send to game (connect a save first)"),
+            new PadOption("Send to game…", IconPath: "storage"),
             new PadOption("Move (carry)", IconPath: "storage"),
             new PadOption("Export .pk file", IconPath: "folder"),
             new PadOption("Release from bank", IconPath: "hex"));
@@ -222,8 +221,8 @@ public sealed class BankPage : ContentPage, IPadHandler
             case "Edit":
                 await EditEntryAsync(entry);
                 return;
-            case "Send to game":
-                await SendToGameAsync(entry);
+            case "Send to game…":
+                await SendToGamePickerAsync(entry);
                 return;
             case "Move (carry)":
                 _carryId = entry.Id;
@@ -341,26 +340,28 @@ public sealed class BankPage : ContentPage, IPadHandler
         _canvas.InvalidateSurface();
     }
 
-    /// <summary>Withdraw: convert the stored bytes into the connected save's first empty slot.</summary>
-    private async Task SendToGameAsync(BankEntry entry)
+    /// <summary>Withdraw into ANY detected game: pick the destination, the transfer service
+    /// converts the format, backs up, and writes. No need to connect the save first.</summary>
+    private async Task SendToGamePickerAsync(BankEntry entry)
     {
-        if (_boxViewModel.Save is null)
+        var services = IPlatformApplication.Current?.Services;
+        var picker = services?.GetService<SavePickerViewModel>();
+        var transfer = services?.GetService<Services.TransferService>();
+        if (picker is null || transfer is null) return;
+
+        var connectedDoc = services?.GetService<ISaveSessionService>()?.Current?.Document.DocumentId;
+        var target = await SavePickerSheet.PickAsync(_hostGrid, picker.Saves,
+            "SEND TO GAME", $"{entry.Info.Nickname} → pick the destination", connectedDoc);
+        if (target is null)
         {
-            _boxViewModel.Status = "Connect a save first.";
+            if (connectedDoc is null && picker.Saves.Count == 0)
+                _boxViewModel.Status = "No games linked. Link an emulator on Home first.";
             return;
         }
-        var target = _boxViewModel.VisibleSlots.FirstOrDefault(s => s.Species is null)?.Slot ?? -1;
-        if (target < 0)
-        {
-            _boxViewModel.Status = "No empty slot in the game's current box.";
-            return;
-        }
-        var bytes = _bank.GetData(entry.Id);
-        var ok = await _boxViewModel.RunMutationAsync(session =>
-            session.ImportSlot(_boxViewModel.BoxIndex, target, bytes)
-                ? new GenerationOutcome(true, $"{entry.Info.Nickname} joined the game.")
-                : new GenerationOutcome(false, "This mon cannot enter this game's format."), target);
-        if (ok)
+
+        var outcome = await transfer.SendToGameAsync(_bank.GetData(entry.Id), entry.Info.Nickname, target);
+        _boxViewModel.Status = outcome.Message;
+        if (outcome.Success)
         {
             _bank.Remove(entry.Id);
             RefreshBoxEntries();

--- a/src/PKForge.App/Views/BoxBrowserPage.cs
+++ b/src/PKForge.App/Views/BoxBrowserPage.cs
@@ -267,6 +267,7 @@ public sealed class BoxBrowserPage : ContentPage, IPadHandler
     {
         var choice = await PadMenu.ShowAsync(_hostGrid, $"ORGANIZER · {_viewModel.MarkedCount} MARKED", null,
             new PadOption("Move selection to box…", IconPath: "storage"),
+            new PadOption("Move selection to another game…", IconPath: "storage"),
             new PadOption("Move selection to Bank", IconPath: "bank"),
             new PadOption("Export selection (.pk files)", IconPath: "folder"),
             new PadOption("Release selection", IconPath: "hex"),
@@ -281,6 +282,45 @@ public sealed class BoxBrowserPage : ContentPage, IPadHandler
                 if (target is null) return;
                 var boxIndex = Array.IndexOf(boxes, target);
                 await _viewModel.BulkMoveAsync(boxIndex);
+                _canvas.InvalidateSurface();
+                return;
+            }
+            case "Move selection to another game…":
+            {
+                if (_viewModel.MarkedCount == 0) { _viewModel.Status = "Nothing marked."; return; }
+                var session = _sessionsFor();
+                var picker = IPlatformApplication.Current?.Services.GetService<SavePickerViewModel>();
+                var transfer = IPlatformApplication.Current?.Services.GetService<Services.TransferService>();
+                if (session is null || picker is null || transfer is null) return;
+
+                var currentDoc = IPlatformApplication.Current?.Services.GetService<ISaveSessionService>()?.Current?.Document.DocumentId;
+                var target = await SavePickerSheet.PickAsync(_hostGrid, picker.Saves,
+                    "MOVE SELECTION TO GAME", $"{_viewModel.MarkedCount} Pokémon leave this box", currentDoc);
+                if (target is null) return;
+
+                var confirm = await PadMenu.ConfirmAsync(_hostGrid, "MOVE SELECTION?",
+                    $"{_viewModel.MarkedCount} Pokémon will leave this box and join {target.GameLabel}. Mons that cannot enter that format stay here.", "Move all");
+                if (!confirm) return;
+
+                var sentSlots = new List<(int Box, int Slot)>();
+                var skipped = 0;
+                foreach (var (box, markedSlot) in _viewModel.MarkedSlots.ToArray())
+                {
+                    var export = session.ExportSlot(box, markedSlot);
+                    var outcome = await transfer.SendToGameAsync(export.Data, export.FileName, target);
+                    if (outcome.Success) sentSlots.Add((box, markedSlot));
+                    else skipped++;
+                }
+                if (sentSlots.Count == 0)
+                {
+                    _viewModel.Status = skipped > 0 ? $"No Pokémon could enter {target.GameLabel}'s format." : "Transfer failed.";
+                    return;
+                }
+                // Only the mons that actually arrived leave this save; the rest stay marked.
+                var moved = await _viewModel.BulkReleaseAsync(sentSlots);
+                _viewModel.Status = skipped > 0
+                    ? $"Moved {sentSlots.Count} to {target.GameLabel}; {skipped} could not enter that format and stayed."
+                    : $"Moved {sentSlots.Count} Pokémon to {target.GameLabel}.";
                 _canvas.InvalidateSurface();
                 return;
             }
@@ -1121,6 +1161,7 @@ public sealed class BoxBrowserPage : ContentPage, IPadHandler
             new PadOption("Edit (side panel)", IconPath: "editor"),
             new PadOption("Move", IconPath: "storage"),
             new PadOption("Send to Bank", IconPath: "bank"),
+            new PadOption("Send to another game…", IconPath: "storage"),
             new PadOption("Export .pk file", IconPath: "folder"),
             new PadOption("Show as Showdown set", IconPath: "script"),
             new PadOption("Show as QR code", IconPath: "search"),
@@ -1132,6 +1173,9 @@ public sealed class BoxBrowserPage : ContentPage, IPadHandler
                 return;
             case "Send to Bank":
                 await SendToBankAsync(slot, nickname);
+                return;
+            case "Send to another game…":
+                await SendSlotToAnotherGameAsync(slot, nickname);
                 return;
             case "Export .pk file":
                 await ExportSlotAsync(slot);
@@ -1148,6 +1192,44 @@ public sealed class BoxBrowserPage : ContentPage, IPadHandler
             default:
                 return; // Edit: the editor is already open on the right
         }
+    }
+
+    /// <summary>
+    /// Game-to-game: pick any other detected save, the transfer service converts and
+    /// writes there, then the mon leaves this box (a real move, not a copy).
+    /// </summary>
+    private async Task SendSlotToAnotherGameAsync(int slot, string nickname)
+    {
+        var services = IPlatformApplication.Current?.Services;
+        var picker = services?.GetService<SavePickerViewModel>();
+        var transfer = services?.GetService<Services.TransferService>();
+        var session = _sessionsFor();
+        if (picker is null || transfer is null || session is null) return;
+
+        var currentDoc = IPlatformApplication.Current?.Services.GetService<ISaveSessionService>()?.Current?.Document.DocumentId;
+        var target = await SavePickerSheet.PickAsync(_hostGrid, picker.Saves,
+            "SEND TO GAME", $"{nickname} → pick the destination (the mon leaves this box)", currentDoc);
+        if (target is null)
+        {
+            if (picker.Saves.Count == 0)
+                _viewModel.Status = "No other games linked. Link another emulator or save on Home.";
+            return;
+        }
+
+        var confirm = await PadMenu.ConfirmAsync(_hostGrid, "MOVE TO ANOTHER GAME?",
+            $"{nickname} will leave this box and join {target.GameLabel} (box space permitting).", "Move");
+        if (!confirm) return;
+
+        var export = session.ExportSlot(_viewModel.BoxIndex, slot);
+        var outcome = await transfer.SendToGameAsync(export.Data, nickname, target);
+        _viewModel.Status = outcome.Message;
+        if (!outcome.Success) return;
+
+        await _viewModel.RunMutationAsync(s =>
+        {
+            s.ReleaseSlot(_viewModel.BoxIndex, slot);
+            return new GenerationOutcome(true, $"{nickname} moved to {target.GameLabel}.");
+        }, slot);
     }
 
     /// <summary>Writes the decrypted .pk* file and hands it to Android's share sheet.</summary>

--- a/src/PKForge.App/Views/SavePickerSheet.cs
+++ b/src/PKForge.App/Views/SavePickerSheet.cs
@@ -1,0 +1,32 @@
+using PKForge.Domain;
+
+namespace PKForge.App.Views;
+
+/// <summary>
+/// The transfer destination sheet: detected games as a pad menu, with emulator logos.
+/// Returns the chosen save, or null on cancel.
+/// </summary>
+public static class SavePickerSheet
+{
+    public static async Task<DetectedSave?> PickAsync(
+        Grid host, IReadOnlyList<DetectedSave> saves, string title, string? message, string? excludeDocumentId = null)
+    {
+        var candidates = saves.Where(s => s.DocumentId != excludeDocumentId).ToArray();
+        if (candidates.Length == 0) return null;
+
+        var options = candidates.Select(s => new PadOption(s.GameLabel, IconPath: IconFor(s.Emulator))).ToArray();
+        var choice = await PadMenu.ShowAsync(host, title, message, options);
+        if (choice is null) return null;
+        var index = Array.FindIndex(options, o => o.Label == choice);
+        return index >= 0 ? candidates[index] : null;
+    }
+
+    private static string IconFor(EmulatorKind kind) => kind switch
+    {
+        EmulatorKind.RetroArch => "retroarch",
+        EmulatorKind.MelonDS => "melonds",
+        EmulatorKind.Azahar => "azahar",
+        EmulatorKind.Eden => "eden",
+        _ => "storage",
+    };
+}

--- a/tests/PKForge.Engine.Tests/CrossFormatImportTests.cs
+++ b/tests/PKForge.Engine.Tests/CrossFormatImportTests.cs
@@ -1,0 +1,72 @@
+using PKForge.Engine;
+using Xunit;
+
+namespace PKForge.Engine.Tests;
+
+/// <summary>
+/// The transfer primitive behind bank-to-game and game-to-game: a loose entity from an
+/// older generation must convert and land in the open save via ImportSlot. This is the
+/// exact path TransferService drives; any format that fails to convert breaks transfers.
+/// </summary>
+public sealed class CrossFormatImportTests
+{
+    private static string CorpusPath(string file)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "PKForge.sln")))
+            directory = directory.Parent;
+        Assert.NotNull(directory);
+        return Path.Combine(directory!.FullName, "external", "PKHeX", "Tests", "PKHeX.Core.Tests", "TestData", file);
+    }
+
+    [Fact]
+    public void OlderGenerationEntitiesConvertIntoTheOpenSave()
+    {
+        var root = Path.Combine(Path.GetDirectoryName(CorpusPath("SM Project 802.main"))!, "..");
+        var entities = Directory.EnumerateFiles(Path.GetFullPath(root), "*.*", SearchOption.AllDirectories)
+            // Mainline formats only (pk1-6). LGPE (.pb7) is a separate transfer lineage:
+            // the engine intentionally cannot convert it to mainline, and transfers from
+            // it correctly report "cannot enter this game's format" instead of corrupting.
+            .Where(f => System.Text.RegularExpressions.Regex.IsMatch(Path.GetExtension(f), @"^\.pk[1-6]$"))
+            .ToList();
+        Assert.NotEmpty(entities);
+
+        var engine = new SaveEngine();
+        using var session = new SaveEngineSession(File.ReadAllBytes(CorpusPath("SM Project 802.main")));
+        var emptySlots = new Queue<(int Box, int Slot)>(
+            session.Snapshot.Slots.Where(s => s.Species is null).Select(s => (s.Box, s.Slot)));
+        Assert.NotEmpty(emptySlots);
+
+        var failures = new List<string>();
+        var imported = 0;
+        foreach (var file in entities)
+        {
+            if (emptySlots.Count == 0) break;
+            var name = Path.GetFileName(file);
+            var bytes = File.ReadAllBytes(file);
+            var (box, slot) = emptySlots.Dequeue();
+            try
+            {
+                if (!session.ImportSlot(box, slot, bytes))
+                {
+                    failures.Add($"convert returned false: {name}");
+                    continue;
+                }
+                var detail = session.ReadEntity(box, slot);
+                if (detail.IsEmpty)
+                {
+                    failures.Add($"empty after import: {name}");
+                    continue;
+                }
+                imported++;
+            }
+            catch (Exception error)
+            {
+                failures.Add($"THREW {error.GetType().Name} on {name}");
+            }
+        }
+
+        Assert.True(failures.Count == 0 && imported > 0,
+            $"Imported {imported}/{entities.Count}. Failures:\n  " + string.Join("\n  ", failures.Take(20)));
+    }
+}


### PR DESCRIPTION
Smoother transfer UX:

- Bank: Send to game now picks any detected save (no connect-first requirement), converts the format, lands in the first empty slot across all boxes, backs up and writes atomically
- Box: Send to another game moves a mon straight into another save (leaves the source box, confirmed first)
- Organizer: bulk move selection to another game; only mons that actually arrive leave the source save
- New engine test: 112/112 mainline corpus entities convert into a newer save (LGPE correctly reports incompatible)

30/30 tests green.